### PR TITLE
-Fix : inconsistency in videoLength  / duplicate offline analytics events  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* `3.4.1` Release - [3.4.1](#341)
 * `3.4.0` Release - [3.4.0](#340)
 * `3.3.0` Release - [3.3.0](#330)
 * `3.2.1` Release - [3.2.1](#321)
@@ -51,6 +52,12 @@
 * `0.1.x` Releases - [0.1.0](#010) | [0.1.1](#011) | [0.1.2](#012) | [0.1.3](#013) | [0.1.4](#014) | [0.1.5](#015) | [0.1.6](#016) | [0.1.7](#017) | [0.1.8](#018) | [0.1.9](#019)
 
 
+## 3.4.1
+#### Bug Fix
+* `EMP-21115` Resolved the inconsistency in reporting VideoLength within `Playback.Started` events.
+* `EMP-21114` Fixed an issue related to duplicate offline analytics events
+*  Corrected the typo issue : `flushOfflineAnalytics()`
+
 ## 3.4.0
 #### Features
 * `EMP-13788` Add support for analytics events `Playback.AppBackgrounded` , `Playback.AppResumed` & `Playback.GracePeriodEnded`
@@ -76,7 +83,6 @@
 * `EMP-19630` pass `deviceMake`, `deviceModel` when making entitlement calls for playback & downloads. 
 * `EMP-19630` Added new ssai params `ifa`, `ifaType` & `limitAdTracking`
 * `EMP-19630` change the value of the `deviceType` to `ctv,tablet or mobile` in ssai params in SDK as fallback values.  
-
 
 ## 3.1.600
 #### Changes

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The Swift Package Manager is a tool for automating the distribution of Swift cod
 Once you have your Swift package set up, adding `iOSClientExposure` as a dependency is as easy as adding it to the dependencies value of your Package.swift.
 ```sh
 dependencies: [
-    .package(url: "https://github.com/EricssonBroadcastServices/iOSClientExposure", from: "3.4.0")
+    .package(url: "https://github.com/EricssonBroadcastServices/iOSClientExposure", from: "3.4.1")
 ]
 ```
 
@@ -77,7 +77,7 @@ Finally, make sure you add the `.framework`s to your targets *General -> Embedde
 CocoaPods is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate `iOSClientExposure` into your Xcode project using CocoaPods, specify it in your Podfile:
 
 ```sh
-pod 'iOSClientExposure', '~>  3.4.0'
+pod 'iOSClientExposure', '~>  3.4.1'
 ```
 
 ## Getting Started

--- a/Sources/iOSClientExposure/Entitlements/Response/PlaybackEntitlement.swift
+++ b/Sources/iOSClientExposure/Entitlements/Response/PlaybackEntitlement.swift
@@ -114,7 +114,9 @@ public struct PlaybackEntitlement: Codable {
     
     public let epg: EPG?
     
-    public init( assetId: String?, accountId: String?, audioOnly: Bool?, playTokenExpiration: String, mediaLocator: URL, playSessionId: String, live: Bool, ffEnabled: Bool, timeshiftEnabled: Bool, rwEnabled: Bool, airplayBlocked: Bool, playToken: String?, fairplay: FairplayConfiguration?, licenseExpiration: String?, licenseExpirationReason: String?, licenseActivation: String?, entitlementType: String?, minBitrate: Int64?, maxBitrate: Int64?, maxResHeight: Int?, mdnRequestRouterUrl: String?, lastViewedOffset: Int?, lastViewedTime: Int64?, liveTime: Int64?, productId: String?, adMediaLocator: URL? , cdn: CDNInfoFromEntitlement? = nil, analytics: AnalyticsFromEntitlement? = nil, liveDelay: Int64? = nil , epg: EPG? = nil ) {
+    public let durationInMs: Double?
+    
+    public init( assetId: String?, accountId: String?, audioOnly: Bool?, playTokenExpiration: String, mediaLocator: URL, playSessionId: String, live: Bool, ffEnabled: Bool, timeshiftEnabled: Bool, rwEnabled: Bool, airplayBlocked: Bool, playToken: String?, fairplay: FairplayConfiguration?, licenseExpiration: String?, licenseExpirationReason: String?, licenseActivation: String?, entitlementType: String?, minBitrate: Int64?, maxBitrate: Int64?, maxResHeight: Int?, mdnRequestRouterUrl: String?, lastViewedOffset: Int?, lastViewedTime: Int64?, liveTime: Int64?, productId: String?, adMediaLocator: URL? , cdn: CDNInfoFromEntitlement? = nil, analytics: AnalyticsFromEntitlement? = nil, liveDelay: Int64? = nil , epg: EPG? = nil,  durationInMs: Double? = nil  ) {
         
         self.accountId = accountId
         self.assetId = assetId
@@ -146,6 +148,7 @@ public struct PlaybackEntitlement: Codable {
         self.analytics = analytics
         self.liveDelay = liveDelay
         self.epg = epg
+        self.durationInMs = durationInMs
     }
 }
 
@@ -194,6 +197,7 @@ extension PlaybackEntitlement {
         
         liveDelay = try container.decodeIfPresent(Int64.self, forKey: .liveDelay)
         epg = try container.decodeIfPresent(EPG.self, forKey: .epg)
+        durationInMs = try container.decodeIfPresent(Double.self, forKey: .durationInMs)
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -238,6 +242,7 @@ extension PlaybackEntitlement {
         
         try container.encodeIfPresent(liveDelay, forKey: .liveDelay)
         try container.encodeIfPresent(epg, forKey: .epg)
+        try container.encodeIfPresent(durationInMs, forKey: .durationInMs)
     }
     
     internal enum CodingKeys: String, CodingKey {
@@ -267,12 +272,10 @@ extension PlaybackEntitlement {
         case liveTime
         case productId
         case adMediaLocator
-        
         case cdn
         case analytics
-        
         case liveDelay
-        
         case epg
+        case durationInMs
     }
 }

--- a/Sources/iOSClientExposure/Services/Dispatcher/BackgroundAnalyticsManager.swift
+++ b/Sources/iOSClientExposure/Services/Dispatcher/BackgroundAnalyticsManager.swift
@@ -17,7 +17,7 @@ public class BackgroundAnalyticsManager {
     public init() {}
 
     /// Pass notification `didRefreshedInBackgroundNotification`
-    public func fushOfflineAnalytics() {
+    public func flushOfflineAnalytics() {
         let notificationName = "didRefreshedInBackgroundNotification"
         NotificationCenter.default.post(name:  NSNotification.Name(rawValue:notificationName), object: nil)
     }

--- a/Sources/iOSClientExposure/Version.swift
+++ b/Sources/iOSClientExposure/Version.swift
@@ -8,4 +8,4 @@
 import Foundation
 
 /// Global constant for framework version
-public let ExposureVersion = "3.4.0"
+public let ExposureVersion = "3.4.1"

--- a/iOSClientExposure.podspec
+++ b/iOSClientExposure.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 spec.name         = "iOSClientExposure"
-spec.version      = "3.4.0"
+spec.version      = "3.4.1"
 spec.summary      = "RedBeeMedia iOS SDK Exposure Module"
 spec.homepage     = "https://github.com/EricssonBroadcastServices"
 spec.license      = { :type => "Apache", :file => "https://github.com/EricssonBroadcastServices/iOSClientExposure/blob/master/LICENSE" }

--- a/iOSClientExposure.xcodeproj/project.pbxproj
+++ b/iOSClientExposure.xcodeproj/project.pbxproj
@@ -1947,7 +1947,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.0;
+				MARKETING_VERSION = 3.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Exposure;
 				PRODUCT_NAME = iOSClientExposure;
 				SDKROOT = iphoneos;
@@ -1980,7 +1980,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.0;
+				MARKETING_VERSION = 3.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Exposure;
 				PRODUCT_NAME = iOSClientExposure;
 				SDKROOT = iphoneos;
@@ -2013,7 +2013,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.0;
+				MARKETING_VERSION = 3.4.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Exposure;
 				PRODUCT_NAME = iOSClientExposure;
@@ -2047,7 +2047,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.0;
+				MARKETING_VERSION = 3.4.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.emp.Exposure;
 				PRODUCT_NAME = iOSClientExposure;


### PR DESCRIPTION
- Resolved the inconsistency in reporting VideoLength within `Playback.Started` events.
- Fixed an issue related to duplicate offline analytics events
- Corrected the typo issue : `flushOfflineAnalytics()`
- update change log , version , pod specs